### PR TITLE
#10 : Jira 연동 Github Actions 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,10 +3,15 @@ description: Request new Feature
 title: "[FEATURE]: "
 labels: ["🌱기능🌱"]
 body:
-  - type: markdown
+  - type: input
+    id: parentKey
     attributes:
-      value: |
-        이번 이슈도 파이팅 화이팅 🔥
+      label: Epic Ticket Number
+      description: 에픽 Ticket Number를 기입해주세요
+      placeholder: WS-38
+    validations:
+      required: true
+
   - type: textarea
     id: new-feature
     attributes:
@@ -15,6 +20,7 @@ body:
       placeholder: Splash API를 활용한 스플래쉬 화면 구현 
     validations:
       required: true
+
   - type: textarea
     id: todo
     attributes:
@@ -22,6 +28,7 @@ body:
       description: 작업사항을 나누어 작성해주세요! 
       value: |
         - [ ] todo1
+
   - type: textarea
     id: etc
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
     id: parentKey
     attributes:
       label: Epic Ticket Number
-      description: 에픽 Ticket Number를 기입해주세요
+      description: WS-38 - 회원가입/로그인 | WS-42 - 투표 | WS-51 - 마음 | WS-46 - 보관함 | WS-66 - 전체 | WS-74 알림
       placeholder: WS-38
     validations:
       required: true

--- a/.github/workflows/close-jira-issue.yml
+++ b/.github/workflows/close-jira-issue.yml
@@ -1,0 +1,30 @@
+name: Close Jira issue
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  test-transition-issue:
+    name: Transition Issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Find in Jira ticket
+        uses: atlassian/gajira-find-issue-key@master
+        id: jira-ticket
+        with:
+          from: commits
+
+      - name: Transition issue
+        if: steps.jira-ticket.outputs.issue != ''
+        uses: atlassian/gajira-transition@master
+        with:
+          issue: ${{ steps.jira-ticket.outputs.issue }}
+          transition: "완료"

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -9,6 +9,16 @@ jobs:
     name: Create Jira issue
     runs-on: ubuntu-latest
     steps:
+      - name: Get Jira Assignee From PR Author
+        id: jira-assignee
+        run: |
+          AUTHOR=${{ github.event.issue.user.login }}
+          if [ "$AUTHOR" == "jeongjaino" ]; then
+            echo "::set-output name=accountId::${{ secrets.JACOB_ACCOUNT_ID }}"
+          else
+            echo "::set-output name=accountId::${{ secrets.BROWNIES_ACCOUNT_ID }}"
+          fi
+
       - name: Login
         uses: atlassian/gajira-login@v3
         env:
@@ -54,6 +64,9 @@ jobs:
             {
               "parent": {
                 "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              },
+              "assignee" : { 
+                "id" : "${{ steps.jira-assignee.outputs.accountId }}"
               }
             }
 

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,73 @@
+name: Create Jira issue
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  create-issue:
+    name: Create Jira issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Checkout main code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Issue Parser
+        uses: stefanbuck/github-issue-praser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/feature_request.yml
+
+      - name: Log Issue Parser
+        run: |
+          echo '${{ steps.issue-parser.outputs.jsonString }}'
+
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+          input-text: |
+            ### Github Issue Link
+            - ${{ github.event.issue.html_url }}
+            
+            ${{ github.event.issue.body }}
+          mode: md2jira
+
+      - name: Create Issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: WeSpot
+          issuetype: Subtask
+          summary: "${{ github.event.issue.title }}"
+          description: "${{ steps.md2jira.outputs.output-text }}"
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue-parser.outputs.issueparser_parentKey }}"
+              }
+            }
+
+      - name: Log created issue
+        run: echo "Jira Issue ${{ steps.issue-parser.outputs.parentKey }}/${{ steps.create.outputs.issue }} was created"
+
+      - name: Checkout develop code
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Update issue title
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "update-issue"
+          token: ${{ secrets.ACCESS_GITHUB_TOKEN }}
+          title: "${{ steps.create.outputs.issue }} ${{ github.event.issue.title }}"


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#10 Github - Jira Issue 연동 Github Actions 구현 

## 2. 🔥 변경된 점
- 이슈 템플릿이 변경되었습니다. 
  - 에픽 번호 필수 삽입헤야 함 ! (이미 써니가 다 만들어놨더라고요 ???? 이슈 힌트에 넣어놔서, 그거 보고 기입하면 됨 ! )
    - 에픽번호 입력하면, 자동으로 등록해드림 ㅎㅎ  
- 깃헙 이슈 생성시 지라 테스크 자동 생성 액션 구현하였습니다.
  -  이슈에서 등록한 에픽을 그대로 상위 테스크로 지정합니다.
  - 이슈 생성자를 지라에 담당자로 지정합니다. 
  - Jira 이슈 정상 생성시, Github Issue 타이틀 앞에 지라 티켓 번호를 추가합니다. 


## 3. ✅ 필수 체크 사항 
마지막 이 액션 무섭당... 

```yaml
      - name: Update issue title
        uses: actions-cool/issues-helper@v3
        with:
          actions: "update-issue"
          token: ${{ secrets.ACCESS_GITHUB_TOKEN }}
          title: "${{ steps.create.outputs.issue }} ${{ github.event.issue.title }}"
```
- 일단 Full 권한으로 구현했는데, 이슈 쓰는 권한이 포함되어 있는지 확인해봐야함. 액션 터질수도 히히 


## 4. 📸 작업물 사진 공유(선택)
### 지라 생성 예시 
![image](https://github.com/YAPP-Github/WeSpot-Android/assets/77484719/f2a11c67-a570-480b-bb24-ba666736116a)

### 지라 액션 예시
- 이전 프로젝트 지라에서 확인해봤어요 히히  
![image](https://github.com/YAPP-Github/WeSpot-Android/assets/77484719/004b708b-e079-4445-bd19-e1ca70ae3207)

### 변경 이슈 예시 
![image](https://github.com/YAPP-Github/WeSpot-Android/assets/77484719/3b5af03f-18c5-493e-9e70-db6a85cfb711)


## 5. 💡알게된 혹은 궁금한 사항

#### 참고 레퍼런스 
-https://velog.io/@sangpok/Github-%ED%98%91%EC%97%85-%EC%84%A4%EC%A0%95Github-Issue-Jira-%EC%97%B0%EB%8F%99#create-jira-issueyml

- PS. 승원짱이 올려준 파이썬으로 구현된 액션도 좋지만,, 아마 내용이 깨질꺼에요 .. (컨버팅 액션이없음.)
- pre-commit-message를 통해 자동 티켓번호 삽입 로직 구현 예정