### PR TITLE
#43, #44 : 쪽지 신고/차단/삭제 기능 구현 

### DIFF
--- a/core/model/src/main/kotlin/com/bff/wespot/model/message/response/Message.kt
+++ b/core/model/src/main/kotlin/com/bff/wespot/model/message/response/Message.kt
@@ -5,9 +5,16 @@ import java.time.LocalDateTime
 data class Message(
     val id: Int,
     val senderName: String,
+    val receiverId: Int,
+    val receiverName: String,
+    val receiverSchoolName: String,
+    val receiverGrade: Int,
+    val receiverClassNumber: Int,
     val content: String,
-    val receivedAt: LocalDateTime,
+    val receivedAt: LocalDateTime?,
     val isRead: Boolean,
-    val isBlocked: Boolean,
+    val isBlocked: Boolean = false,
     val readAt: LocalDateTime?,
-)
+) {
+    constructor() : this(-1, "", -1, "", "", -1, -1, "", LocalDateTime.MAX, false, false, null)
+}

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/di/DataRemoteModule.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/di/DataRemoteModule.kt
@@ -4,6 +4,8 @@ import com.bff.wespot.data.remote.source.auth.AuthDataSource
 import com.bff.wespot.data.remote.source.auth.AuthDataSourceImpl
 import com.bff.wespot.data.remote.source.message.MessageDataSource
 import com.bff.wespot.data.remote.source.message.MessageDataSourceImpl
+import com.bff.wespot.data.remote.source.message.MessageStorageDataSource
+import com.bff.wespot.data.remote.source.message.MessageStorageDataSourceImpl
 import com.bff.wespot.data.remote.source.user.UserDataSource
 import com.bff.wespot.data.remote.source.user.UserDataSourceImpl
 import com.bff.wespot.data.remote.source.vote.VoteDataSource
@@ -40,4 +42,10 @@ abstract class DataRemoteModule {
     abstract fun bindsUserDataSource(
         userDataSourceImpl: UserDataSourceImpl
     ): UserDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsMessageStorageDataSource(
+        messageStorageDataSourceImpl: MessageStorageDataSourceImpl
+    ): MessageStorageDataSource
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/extensions/DateTimeExtensions.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/extensions/DateTimeExtensions.kt
@@ -3,5 +3,7 @@ package com.bff.wespot.data.remote.extensions
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-fun String.toISOLocalDateTime(): LocalDateTime =
-    LocalDateTime.parse(this, DateTimeFormatter.ISO_DATE_TIME)
+fun String.toISOLocalDateTime(): LocalDateTime? =
+    runCatching {
+        LocalDateTime.parse(this, DateTimeFormatter.ISO_DATE_TIME)
+    }.getOrNull()

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/model/message/response/MessageDto.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/model/message/response/MessageDto.kt
@@ -5,20 +5,30 @@ import com.bff.wespot.data.remote.extensions.toISOLocalDateTime
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MessageDto (
+data class MessageDto(
     val id: Int,
     val senderName: String,
+    val receiverId: Int,
+    val receiverName: String,
+    val receiverSchoolName: String,
+    val receiverGrade : Int,
+    val receiverClassNumber : Int,
     val content: String,
-    val receivedAt: String,
+    val receivedAt: String?,
     val isRead: Boolean,
     val isBlocked: Boolean,
-    val readAt: String?,
+    val readAt: String?
 ) {
     fun toMessage(): Message = Message(
         id = id,
         senderName = senderName,
+        receiverId = receiverId,
+        receiverName = receiverName,
+        receiverSchoolName = receiverSchoolName,
+        receiverGrade = receiverGrade,
+        receiverClassNumber = receiverClassNumber,
         content = content,
-        receivedAt = receivedAt.toISOLocalDateTime(),
+        receivedAt = receivedAt?.toISOLocalDateTime(),
         isRead = isRead,
         isBlocked = isBlocked,
         readAt = readAt?.toISOLocalDateTime(),

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageDataSource.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageDataSource.kt
@@ -15,6 +15,4 @@ interface MessageDataSource {
     suspend fun getMessageStatus(): Result<MessageStatusDto>
 
     suspend fun checkProfanity(content: MessageContentDto): Result<Unit>
-
-    suspend fun updateMessageReadStatus(messageId: Int): Result<Unit>
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageDataSourceImpl.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageDataSourceImpl.kt
@@ -55,12 +55,4 @@ class MessageDataSourceImpl @Inject constructor(
                 setBody(content)
             }
         }
-
-    override suspend fun updateMessageReadStatus(messageId: Int): Result<Unit> =
-        httpClient.safeRequest {
-            url {
-                method = HttpMethod.Put
-                path("messages/$messageId/read")
-            }
-        }
 }

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageStorageDataSource.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageStorageDataSource.kt
@@ -1,0 +1,11 @@
+package com.bff.wespot.data.remote.source.message
+
+interface MessageStorageDataSource {
+    suspend fun updateMessageReadStatus(messageId: Int): Result<Unit>
+
+    suspend fun deleteMessage(messageId: Int): Result<Unit>
+
+    suspend fun blockMessage(messageId: Int): Result<Unit>
+
+    suspend fun reportMessage(messageId: Int): Result<Unit>
+}

--- a/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageStorageDataSourceImpl.kt
+++ b/data-remote/src/main/kotlin/com/bff/wespot/data/remote/source/message/MessageStorageDataSourceImpl.kt
@@ -1,0 +1,43 @@
+package com.bff.wespot.data.remote.source.message
+
+import com.bff.wespot.network.extensions.safeRequest
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpMethod
+import io.ktor.http.path
+import javax.inject.Inject
+
+class MessageStorageDataSourceImpl @Inject constructor(
+    private val httpClient: HttpClient,
+) : MessageStorageDataSource {
+    override suspend fun updateMessageReadStatus(messageId: Int): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Put
+                path("messages/$messageId/read")
+            }
+        }
+
+    override suspend fun deleteMessage(messageId: Int): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Delete
+                path("messages/$messageId")
+            }
+        }
+
+    override suspend fun blockMessage(messageId: Int): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Post
+                path("messages/$messageId/block")
+            }
+        }
+
+    override suspend fun reportMessage(messageId: Int): Result<Unit> =
+        httpClient.safeRequest {
+            url {
+                method = HttpMethod.Post
+                path("messages/$messageId/report")
+            }
+        }
+}

--- a/data/src/main/kotlin/com/bff/wespot/data/di/DataModule.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/di/DataModule.kt
@@ -4,12 +4,14 @@ import com.bff.wespot.data.repository.DataStoreRepositoryImpl
 import com.bff.wespot.data.repository.auth.AuthRepositoryImpl
 import com.bff.wespot.data.repository.auth.KakaoLoginManagerImpl
 import com.bff.wespot.data.repository.message.MessageRepositoryImpl
+import com.bff.wespot.data.repository.message.MessageStorageRepositoryImpl
 import com.bff.wespot.data.repository.user.UserRepositoryImpl
 import com.bff.wespot.data.repository.vote.VoteRepositoryImpl
 import com.bff.wespot.domain.repository.DataStoreRepository
 import com.bff.wespot.domain.repository.auth.AuthRepository
 import com.bff.wespot.domain.repository.auth.KakaoLoginManager
 import com.bff.wespot.domain.repository.message.MessageRepository
+import com.bff.wespot.domain.repository.message.MessageStorageRepository
 import com.bff.wespot.domain.repository.user.UserRepository
 import com.bff.wespot.domain.repository.vote.VoteRepository
 import dagger.Binds
@@ -56,4 +58,10 @@ abstract class DataModule {
     abstract fun bindsUserRepository(
         userRepositoryImpl: UserRepositoryImpl
     ): UserRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsMessageStorageRepository(
+        messageStorageRepositoryImpl: MessageStorageRepositoryImpl
+    ): MessageStorageRepository
 }

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/message/MessageRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/message/MessageRepositoryImpl.kt
@@ -19,23 +19,22 @@ class MessageRepositoryImpl @Inject constructor(
     ): Result<MessageList> =
         messageDataSource
             .getMessageList(messageType.toMessageTypeDto())
-            .map { messageListDto ->
+            .mapCatching { messageListDto ->
                 messageListDto.toMessageList()
             }
 
     override suspend fun postMessage(sentMessage: SentMessage): Result<String> {
-        return messageDataSource.postMessage(sentMessage.toSentMessageDto()).map { it.toString() }
+        return messageDataSource.postMessage(sentMessage.toSentMessageDto()).mapCatching {
+            it.toString()
+        }
     }
 
     override suspend fun getMessageStatus(): Result<MessageStatus> {
-        return messageDataSource.getMessageStatus().map { messageStatusDto ->
+        return messageDataSource.getMessageStatus().mapCatching { messageStatusDto ->
             messageStatusDto.toMessageStatus()
         }
     }
 
     override suspend fun checkProfanity(content: String): Result<Unit> =
         messageDataSource.checkProfanity(MessageContentDto(message = content))
-
-    override suspend fun updateMessageReadStatus(messageId: Int): Result<Unit> =
-        messageDataSource.updateMessageReadStatus(messageId = messageId)
 }

--- a/data/src/main/kotlin/com/bff/wespot/data/repository/message/MessageStorageRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/bff/wespot/data/repository/message/MessageStorageRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.bff.wespot.data.repository.message
+
+import com.bff.wespot.data.remote.source.message.MessageStorageDataSource
+import com.bff.wespot.domain.repository.message.MessageStorageRepository
+import javax.inject.Inject
+
+class MessageStorageRepositoryImpl @Inject constructor(
+    private val messageStorageDataSource: MessageStorageDataSource,
+): MessageStorageRepository {
+    override suspend fun updateMessageReadStatus(messageId: Int): Result<Unit> =
+        messageStorageDataSource.updateMessageReadStatus(messageId = messageId)
+
+    override suspend fun deleteMessage(messageId: Int): Result<Unit> =
+        messageStorageDataSource.deleteMessage(messageId = messageId)
+
+    override suspend fun blockMessage(messageId: Int): Result<Unit> =
+        messageStorageDataSource.blockMessage(messageId = messageId)
+
+    override suspend fun reportMessage(messageId: Int): Result<Unit> =
+        messageStorageDataSource.reportMessage(messageId = messageId)
+}

--- a/designsystem/src/main/kotlin/com/bff/wespot/designsystem/component/indicator/WSHomeTabRow.kt
+++ b/designsystem/src/main/kotlin/com/bff/wespot/designsystem/component/indicator/WSHomeTabRow.kt
@@ -49,7 +49,9 @@ fun WSHomeTabRow(
             Tab(
                 selected = selected,
                 onClick = { onTabSelected(index) },
-                modifier = Modifier.padding(11.dp),
+                modifier = Modifier
+                    .padding(vertical = 11.dp)
+                    .then(paddingModifier),
             ) {
                 Text(
                     text = tab,

--- a/designsystem/src/main/kotlin/com/bff/wespot/designsystem/component/input/WsTextField.kt
+++ b/designsystem/src/main/kotlin/com/bff/wespot/designsystem/component/input/WsTextField.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.bff.wespot.designsystem.R
+import com.bff.wespot.designsystem.theme.Gray400
 import com.bff.wespot.designsystem.theme.Primary400
 import com.bff.wespot.designsystem.theme.StaticTypeScale
 import com.bff.wespot.designsystem.theme.WeSpotTheme
@@ -82,7 +83,11 @@ fun WsTextField(
                 null
             },
             placeholder = {
-                Text(text = placeholder, style = StaticTypeScale.Default.body4)
+                Text(
+                    text = placeholder,
+                    style = StaticTypeScale.Default.body4,
+                    color = Gray400,
+                )
             },
             colors = OutlinedTextFieldDefaults.colors(
                 focusedContainerColor = WeSpotThemeManager.colors.cardBackgroundColor,

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/message/MessageRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/message/MessageRepository.kt
@@ -13,6 +13,4 @@ interface MessageRepository {
     suspend fun getMessageStatus(): Result<MessageStatus>
 
     suspend fun checkProfanity(content: String): Result<Unit>
-
-    suspend fun updateMessageReadStatus(messageId: Int): Result<Unit>
 }

--- a/domain/src/main/kotlin/com/bff/wespot/domain/repository/message/MessageStorageRepository.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/repository/message/MessageStorageRepository.kt
@@ -1,0 +1,11 @@
+package com.bff.wespot.domain.repository.message
+
+interface MessageStorageRepository {
+    suspend fun updateMessageReadStatus(messageId: Int): Result<Unit>
+
+    suspend fun deleteMessage(messageId: Int): Result<Unit>
+
+    suspend fun blockMessage(messageId: Int): Result<Unit>
+
+    suspend fun reportMessage(messageId: Int): Result<Unit>
+}

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/model/MessageOptionType.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/model/MessageOptionType.kt
@@ -1,0 +1,47 @@
+package com.bff.wespot.message.model
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.stringResource
+import com.bff.wespot.message.R
+
+enum class MessageOptionType {
+    DELETE,
+    BLOCK,
+    REPORT,
+    ;
+
+    val title
+        @Composable
+        @ReadOnlyComposable
+        get() = when (this) {
+            DELETE -> stringResource(R.string.message_delete_dialog_title)
+            BLOCK -> stringResource(R.string.message_block_dialog_title)
+            REPORT -> stringResource(R.string.message_report_dialog_title)
+        }
+
+    val subTitle
+        @Composable
+        @ReadOnlyComposable
+        get() = when (this) {
+            DELETE -> stringResource(R.string.message_delete_dialog_subtitle)
+            BLOCK -> stringResource(R.string.message_block_dialog_subtitle)
+            REPORT -> stringResource(R.string.message_report_dialog_subtitle)
+        }
+
+    val okButtonText
+        @Composable
+        @ReadOnlyComposable
+        get() = when (this) {
+            DELETE -> stringResource(R.string.message_delete_dialog_ok_button)
+            BLOCK -> stringResource(R.string.message_block_dialog_ok_button)
+            REPORT -> stringResource(R.string.message_report_dialog_ok_button)
+        }
+
+    val cancelButtonText
+        @Composable
+        @ReadOnlyComposable
+        get() = when (this) {
+            DELETE, BLOCK, REPORT -> stringResource(id = R.string.close)
+        }
+}

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
@@ -47,6 +47,8 @@ internal fun MessageScreen(
     navArgs: MessageScreenArgs,
 ) {
     var messageSentToast by remember { mutableStateOf(false) }
+    var showToast by remember { mutableStateOf(false) }
+    var toastMessage by remember { mutableStateOf("") }
     val tabList = persistentListOf(
         stringResource(R.string.message_home_screen),
         stringResource(R.string.message_storage_screen),
@@ -95,6 +97,10 @@ internal fun MessageScreen(
                                     ReceiverSelectionScreenArgs(false),
                                 )
                             },
+                            showToast = { message ->
+                                toastMessage = message
+                                showToast = true
+                            },
                         )
                     }
                 }
@@ -109,6 +115,20 @@ internal fun MessageScreen(
                 toastType = WSToastType.Success,
                 showToast = messageSentToast,
                 closeToast = { messageSentToast = false },
+            )
+        }
+    }
+
+    if (showToast) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
+            WSToast(
+                text = toastMessage,
+                toastType = WSToastType.Success,
+                showToast = showToast && toastMessage.isNotBlank(),
+                closeToast = {
+                    showToast = false
+                    toastMessage = ""
+                },
             )
         }
     }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageWriteScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageWriteScreen.kt
@@ -128,7 +128,7 @@ fun MessageWriteScreen(
                 }
 
                 Text(
-                    modifier = Modifier.padding(top = 4.dp, start = 10.dp, end = 10.dp),
+                    modifier = Modifier.padding(top = 5.dp, start = 10.dp, end = 10.dp),
                     text = warningMessage,
                     style = StaticTypeScale.Default.body7,
                     color = WeSpotThemeManager.colors.dangerColor,
@@ -171,7 +171,7 @@ fun MessageWriteScreen(
     LaunchedEffect(focusRequester) {
         focusRequester.requestFocus()
         delay(10)
-        keyboard?.show()
+        keyboard?.hide()
     }
 
     LaunchedEffect(Unit) {

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
@@ -185,7 +185,7 @@ fun ReceiverSelectionScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(110.dp)
+                .height(124.dp)
                 .background(
                     brush = Brush.verticalGradient(
                         colors = listOf(

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageAction.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageAction.kt
@@ -1,6 +1,6 @@
 package com.bff.wespot.message.state
 
-import com.bff.wespot.message.model.MessageOptionDialog
+import com.bff.wespot.message.model.MessageOptionType
 import com.bff.wespot.model.message.request.MessageType
 import com.bff.wespot.model.message.response.Message
 
@@ -11,7 +11,7 @@ sealed class MessageAction {
     data class OnMessageItemClicked(val message: Message) : MessageAction()
     data class OnOptionButtonClicked(val message: Message) : MessageAction()
     data class OnOptionBottomSheetClicked(
-        val messageOptionDialog: MessageOptionDialog,
+        val messageOptionType: MessageOptionType,
     ) : MessageAction()
     data class OnMessageDeleteButtonClicked(val messageId: Int) : MessageAction()
     data class OnMessageBlockButtonClicked(val messageId: Int) : MessageAction()

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageAction.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageAction.kt
@@ -1,5 +1,6 @@
 package com.bff.wespot.message.state
 
+import com.bff.wespot.message.model.MessageOptionDialog
 import com.bff.wespot.model.message.request.MessageType
 import com.bff.wespot.model.message.response.Message
 
@@ -8,4 +9,11 @@ sealed class MessageAction {
     data object OnMessageStorageScreenEntered : MessageAction()
     data class OnStorageChipSelected(val messageType: MessageType) : MessageAction()
     data class OnMessageItemClicked(val message: Message) : MessageAction()
+    data class OnOptionButtonClicked(val message: Message) : MessageAction()
+    data class OnOptionBottomSheetClicked(
+        val messageOptionDialog: MessageOptionDialog,
+    ) : MessageAction()
+    data class OnMessageDeleteButtonClicked(val messageId: Int) : MessageAction()
+    data class OnMessageBlockButtonClicked(val messageId: Int) : MessageAction()
+    data class OnMessageReportButtonClicked(val messageId: Int) : MessageAction()
 }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageSideEffect.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageSideEffect.kt
@@ -1,3 +1,5 @@
 package com.bff.wespot.message.state
 
-sealed class MessageSideEffect
+sealed class MessageSideEffect {
+    data class ShowToast(val message: String) : MessageSideEffect()
+}

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageUiState.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageUiState.kt
@@ -1,12 +1,12 @@
 package com.bff.wespot.message.state
 
+import com.bff.wespot.message.model.MessageOptionDialog
 import com.bff.wespot.message.model.TimePeriod
 import com.bff.wespot.model.message.response.Message
 import com.bff.wespot.model.message.response.MessageList
 import com.bff.wespot.model.message.response.MessageStatus
 import com.bff.wespot.model.user.response.Profile
 import com.bff.wespot.model.user.response.ProfileCharacter
-import java.time.LocalDateTime
 
 data class MessageUiState(
     val timePeriod: TimePeriod = TimePeriod.DAWN_TO_EVENING,
@@ -14,5 +14,7 @@ data class MessageUiState(
     val receivedMessageList: MessageList = MessageList(listOf(), true),
     val myProfile: Profile = Profile(-1, "", "", -1, -1, "", "", ProfileCharacter("", "")),
     val sentMessageList: MessageList = MessageList(listOf(), true),
-    val clickedMessage: Message = Message(-1, "", "", LocalDateTime.MAX, false, false, null),
+    val clickedMessage: Message = Message(),
+    val optionButtonClickedMessage: Message = Message(),
+    val messageOptionDialog: MessageOptionDialog = MessageOptionDialog.DELETE,
 )

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageUiState.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageUiState.kt
@@ -1,6 +1,6 @@
 package com.bff.wespot.message.state
 
-import com.bff.wespot.message.model.MessageOptionDialog
+import com.bff.wespot.message.model.MessageOptionType
 import com.bff.wespot.message.model.TimePeriod
 import com.bff.wespot.model.message.response.Message
 import com.bff.wespot.model.message.response.MessageList
@@ -16,5 +16,5 @@ data class MessageUiState(
     val sentMessageList: MessageList = MessageList(listOf(), true),
     val clickedMessage: Message = Message(),
     val optionButtonClickedMessage: Message = Message(),
-    val messageOptionDialog: MessageOptionDialog = MessageOptionDialog.DELETE,
+    val messageOptionType: MessageOptionType = MessageOptionType.DELETE,
 )

--- a/feature/message/src/main/res/values/strings.xml
+++ b/feature/message/src/main/res/values/strings.xml
@@ -52,4 +52,16 @@
     <string name="received_message">받은 쪽지</string>
     <string name="reserved_message">보낸 쪽지</string>
     <string name="message_screen_crossfade">Message Screen CrossFade</string>
+    <string name="message_delete_dialog_title">쪽지를 삭제하시나요?</string>
+    <string name="message_delete_dialog_subtitle">삭제한 쪽지는 절대 되돌릴 수 없어요</string>
+    <string name="message_delete_dialog_ok_button">네 삭제할래요</string>
+    <string name="message_block_dialog_title">정말 차단하시나요?</string>
+    <string name="message_block_dialog_subtitle"><![CDATA[해당 친구와의 쪽지 수신 및 발신이 차단돼요\n* 차단 해제 : 전체>설정>차단 목록>차단 해제]]></string>
+    <string name="message_block_dialog_ok_button">네 차단할래요</string>
+    <string name="message_report_dialog_title">정말 신고하시나요?</string>
+    <string name="message_report_dialog_subtitle">허위 신고로 확인될 시 서비스 이용이 제한되며\n받은 쪽지는 신고 즉시 삭제돼요</string>
+    <string name="message_report_dialog_ok_button">네 신고할래요</string>
+    <string name="block">차단</string>
+    <string name="report_title">신고</string>
+    <string name="delete">삭제</string>
 </resources>


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#43 쪽지 삭제 기능 구현 
#44 쪽지 신고/차단 기능 구현 

## 2. 🔥 변경된 점
쪽지 보관함에서 옵션 버튼 클릭시, 쪽지에 대한 처리를 할 수 있도록 구현하였습니당 ~ 
쪽지 삭제/신고/차단을 수행할 수 있어요 

## 3. ✅ 필수 체크 사항 

쪽지 API가 많아지면서, MessageStorage DataSource/Repository를 구현했어요 !

Repository에서 Dto -> Domain Model 변환시 예외가 발생하는 경우, 그대로 크래쉬가 발생했었어요 
- 내부에 map -> mapCatching으로 변경해서 예외 발생시 viewModel에서 onFailure로 잡을 수 있도록 구현했어요

## 4. 📸 작업물 사진 공유(선택)
https://github.com/user-attachments/assets/66f28626-6a47-4f04-a32b-6db615a64154


## 5. 💡알게된 혹은 궁금한 사항
