### PR TITLE
#76 : 푸시 알림 구현 및 권한 / 푸시 알림 화면 전환 

### DIFF
--- a/app/src/main/kotlin/com/bff/wespot/AppNavGraphs.kt
+++ b/app/src/main/kotlin/com/bff/wespot/AppNavGraphs.kt
@@ -124,7 +124,7 @@ object AppNavGraphs {
 
 private val tabScreenNames = listOf(
     "vote/vote_home_screen",
-    "message/message_screen?isMessageSent={isMessageSent}",
+    "message/message_screen?isMessageSent={isMessageSent}&type={type}&messageId={messageId}",
 )
 
 fun NavDestination.navGraph(): NavGraphSpec {

--- a/app/src/main/kotlin/com/bff/wespot/MainActivity.kt
+++ b/app/src/main/kotlin/com/bff/wespot/MainActivity.kt
@@ -1,5 +1,8 @@
 package com.bff.wespot
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -32,14 +35,23 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.rememberNavController
+import com.ramcosta.composedestinations.dynamic.within
 import com.bff.wespot.designsystem.R
 import com.bff.wespot.designsystem.component.header.WSTopBar
 import com.bff.wespot.designsystem.theme.StaticTypeScale
 import com.bff.wespot.designsystem.theme.WeSpotTheme
 import com.bff.wespot.designsystem.theme.WeSpotThemeManager
+import com.bff.wespot.message.screen.MessageScreenArgs
+import com.bff.wespot.message.screen.destinations.MessageScreenDestination
+import com.bff.wespot.message.screen.destinations.ReceiverSelectionScreenDestination
+import com.bff.wespot.message.screen.send.ReceiverSelectionScreenArgs
+import com.bff.wespot.model.notification.NotificationType
+import com.bff.wespot.model.notification.convertNotificationType
 import com.bff.wespot.navigation.Navigator
 import com.ramcosta.composedestinations.navigation.navigate
 import com.ramcosta.composedestinations.spec.NavGraphSpec
@@ -54,18 +66,57 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestNotificationPermission()
 
         setContent {
             WeSpotTheme {
-                MainScreen(navigator)
+                MainScreen(
+                    navigator = navigator,
+                    navArgs = getMainScreenArgsFromIntent(),
+                )
             }
         }
     }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val hasPermission = ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+
+            if(!hasPermission) {
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                    0
+                )
+            }
+        }
+    }
+
+    private fun getMainScreenArgsFromIntent(): MainScreenNavArgs {
+        val targetId = intent.getStringExtra("targetId")?.toInt() ?: -1
+        val date = intent.getStringExtra("date") ?: ""
+        val type = intent.getStringExtra("type") ?: ""
+
+        return MainScreenNavArgs(
+            targetId = targetId,
+            date = date,
+            type = convertNotificationType(type),
+        )
+    }
 }
+
+data class MainScreenNavArgs(
+    val type: NotificationType,
+    val date: String,
+    val targetId: Int,
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun MainScreen(navigator: Navigator) {
+private fun MainScreen(navigator: Navigator, navArgs: MainScreenNavArgs) {
     val navController = rememberNavController()
 
     val checkScreen by navController.checkCurrentScreen()
@@ -123,6 +174,8 @@ private fun MainScreen(navigator: Navigator) {
             modifier = Modifier.padding(it),
             navigator = navigator,
         )
+
+        navigateScreenFromNavArgs(navArgs, navController)
     }
 }
 
@@ -231,6 +284,38 @@ private fun TabItem(
                     WeSpotThemeManager.colors.disableIcnColor
                 },
             )
+        }
+    }
+}
+
+private fun navigateScreenFromNavArgs(navArgs: MainScreenNavArgs, navController: NavController) {
+    when (navArgs.type) {
+        NotificationType.MESSAGE -> {
+            navController.navigate(
+                ReceiverSelectionScreenDestination(
+                    ReceiverSelectionScreenArgs(false),
+                ) within AppNavGraphs.message
+            )
+        }
+
+        NotificationType.MESSAGE_SENT, NotificationType.MESSAGE_RECEIVED -> {
+            navController.navigate(
+                MessageScreenDestination(
+                    MessageScreenArgs(
+                        type = navArgs.type,
+                        messageId = navArgs.targetId,
+                    ),
+                ) within AppNavGraphs.message
+            )
+        }
+
+        NotificationType.VOTE -> {
+        }
+        NotificationType.VOTE_RESULT -> {
+        }
+        NotificationType.VOTE_RECEIVED -> {
+        }
+        NotificationType.IDLE -> {
         }
     }
 }

--- a/app/src/main/kotlin/com/bff/wespot/NavigatorImpl.kt
+++ b/app/src/main/kotlin/com/bff/wespot/NavigatorImpl.kt
@@ -18,8 +18,11 @@ class NavigatorImpl @Inject constructor() : Navigator {
 
     override fun navigateToMain(
         context: Context,
+        targetId: Pair<String, Int>,
+        date: Pair<String, String>,
+        type: Pair<String, String>,
     ): Intent {
-        val intent = context.buildIntent<MainActivity>()
+        val intent = context.buildIntent<MainActivity>(targetId, date, type)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         return intent
     }

--- a/app/src/main/kotlin/com/bff/wespot/PushNotificationService.kt
+++ b/app/src/main/kotlin/com/bff/wespot/PushNotificationService.kt
@@ -1,14 +1,83 @@
 package com.bff.wespot
 
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.media.RingtoneManager
+import androidx.core.app.NotificationCompat
+import com.bff.wespot.auth.AuthActivity
+import com.bff.wespot.common.CHANNEL_ID
+import com.bff.wespot.domain.repository.DataStoreRepository
+import com.bff.wespot.domain.util.DataStoreKey.PUSH_TOKEN
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 class PushNotificationService : FirebaseMessagingService() {
+
+    @Inject
+    lateinit var dataStore: DataStoreRepository
+
+    @Inject
+    lateinit var coroutineDispatcher: CoroutineDispatcher
+    private val coroutineScope by lazy { CoroutineScope(coroutineDispatcher) }
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
+        coroutineScope.launch {
+            dataStore.saveString(PUSH_TOKEN, token)
+        }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
+        if (message.data.isNotEmpty() || message.notification != null) {
+            sendNotification(message)
+        }
+    }
+
+    private fun sendNotification(message: RemoteMessage) {
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val notificationId: Int = (System.currentTimeMillis()).toInt()
+
+        val intent = Intent(this, AuthActivity::class.java)
+        for (key in message.data.keys) {
+            intent.putExtra(key, message.data[key])
+        }
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            notificationId,
+            intent,
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_MUTABLE
+        )
+
+        val title = message.notification?.title
+        val content = message.notification?.body
+        val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+
+        val notificationBuilder = NotificationCompat.Builder(this, CHANNEL_ID)
+            // TODO Set AppIcon
+            .setSmallIcon(R.drawable.ic_launcher_background)
+            .setContentTitle(title)
+            .setContentText(content)
+            .setAutoCancel(true)
+            .setSound(defaultSoundUri)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(Notification.DEFAULT_ALL)
+            .setContentIntent(pendingIntent)
+
+        notificationManager.notify(notificationId, notificationBuilder.build())
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        coroutineScope.cancel()
     }
 }

--- a/app/src/main/kotlin/com/bff/wespot/application/WeSpotApplication.kt
+++ b/app/src/main/kotlin/com/bff/wespot/application/WeSpotApplication.kt
@@ -1,7 +1,13 @@
 package com.bff.wespot.application
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
 import com.bff.wespot.BuildConfig
+import com.bff.wespot.common.CHANNEL_DESCRIPTION
+import com.bff.wespot.common.CHANNEL_ID
+import com.bff.wespot.common.CHANNEL_NAME
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
@@ -12,6 +18,19 @@ class WeSpotApplication : Application() {
         super.onCreate()
         initialTimber()
         initKakaoSdk()
+        initNotificationChannel()
+    }
+
+    private fun initNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+            val importance = NotificationManager.IMPORTANCE_HIGH
+            val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, importance).apply {
+                description = CHANNEL_DESCRIPTION
+            }
+
+            notificationManager.createNotificationChannel(channel)
+        }
     }
 
     private fun initKakaoSdk() {

--- a/app/src/main/kotlin/com/bff/wespot/common/Constants.kt
+++ b/app/src/main/kotlin/com/bff/wespot/common/Constants.kt
@@ -1,0 +1,5 @@
+package com.bff.wespot.common
+
+internal const val CHANNEL_ID = "WeSpot_channel"
+internal const val CHANNEL_NAME = "WeSpot_default_channel"
+internal const val CHANNEL_DESCRIPTION = "WeSpot_notification_channel"

--- a/core/model/src/main/kotlin/com/bff/wespot/model/notification/NotificationType.kt
+++ b/core/model/src/main/kotlin/com/bff/wespot/model/notification/NotificationType.kt
@@ -16,3 +16,14 @@ enum class NotificationType {
         IDLE -> ""
     }
 }
+
+fun convertNotificationType(type: String): NotificationType =
+    when (type) {
+        NotificationType.MESSAGE.name -> NotificationType.MESSAGE
+        NotificationType.MESSAGE_SENT.name -> NotificationType.MESSAGE
+        NotificationType.MESSAGE_RECEIVED.name -> NotificationType.MESSAGE
+        NotificationType.VOTE.name -> NotificationType.MESSAGE
+        NotificationType.VOTE_RESULT.name -> NotificationType.MESSAGE
+        NotificationType.VOTE_RECEIVED.name -> NotificationType.MESSAGE
+        else -> NotificationType.IDLE
+    }

--- a/core/navigation/src/main/kotlin/com/bff/wespot/navigation/Navigator.kt
+++ b/core/navigation/src/main/kotlin/com/bff/wespot/navigation/Navigator.kt
@@ -5,8 +5,12 @@ import android.content.Intent
 import android.net.Uri
 
 interface Navigator {
-
-    fun navigateToMain(context: Context) : Intent
+    fun navigateToMain(
+        context: Context,
+        targetId: Pair<String, Int>,
+        date: Pair<String, String>,
+        type: Pair<String, String>,
+    ) : Intent
 
     fun navigateToAuth(context: Context): Intent
 

--- a/core/navigation/src/main/kotlin/com/bff/wespot/navigation/util/ExtraConstants.kt
+++ b/core/navigation/src/main/kotlin/com/bff/wespot/navigation/util/ExtraConstants.kt
@@ -1,3 +1,6 @@
 package com.bff.wespot.navigation.util
 
 const val EXTRA_TOAST_MESSAGE = "extra_toast_message"
+const val EXTRA_TARGET_ID = "extra_target_id"
+const val EXTRA_DATE= "extra_date"
+const val EXTRA_TYPE = "extra_type"

--- a/domain/src/main/kotlin/com/bff/wespot/domain/util/DataStoreKey.kt
+++ b/domain/src/main/kotlin/com/bff/wespot/domain/util/DataStoreKey.kt
@@ -5,6 +5,7 @@ object DataStoreKey {
     const val REFRESH_TOKEN = "refresh_token"
     const val REFRESH_TOKEN_EXPIRED_AT = "refresh_token_expired_date"
     const val SIGN_UP_TOKEN = "signup_token"
+    const val PUSH_TOKEN = "push_token"
     const val SETTING_DIALOG = "setting_dialog"
     const val VOTE_ONBOARDING = "vote_onboarding"
 }

--- a/feature/auth/src/main/kotlin/com/bff/wespot/auth/AuthActivity.kt
+++ b/feature/auth/src/main/kotlin/com/bff/wespot/auth/AuthActivity.kt
@@ -33,7 +33,10 @@ import com.bff.wespot.designsystem.component.indicator.WSToastType
 import com.bff.wespot.designsystem.theme.WeSpotTheme
 import com.bff.wespot.model.constants.LoginState
 import com.bff.wespot.navigation.Navigator
+import com.bff.wespot.navigation.util.EXTRA_DATE
+import com.bff.wespot.navigation.util.EXTRA_TARGET_ID
 import com.bff.wespot.navigation.util.EXTRA_TOAST_MESSAGE
+import com.bff.wespot.navigation.util.EXTRA_TYPE
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.ramcosta.composedestinations.navigation.dependency
 import com.ramcosta.composedestinations.navigation.navigate
@@ -98,7 +101,12 @@ class AuthActivity : ComponentActivity() {
                     }
 
                     AuthSideEffect.NavigateToMainActivity -> {
-                        val intent = navigator.navigateToMain(this)
+                        val intent = navigator.navigateToMain(
+                            this,
+                            Pair("", 0),
+                            Pair("", ""),
+                            Pair("", ""),
+                        )
                         startActivity(intent)
                     }
                 }
@@ -150,7 +158,16 @@ class AuthActivity : ComponentActivity() {
             override fun onPreDraw(): Boolean {
                 return if (::loginState.isInitialized) {
                     if (loginState == LoginState.LOGIN_SUCCESS) {
-                        val intent = navigator.navigateToMain(this@AuthActivity)
+                        val targetId = intent.getStringExtra("targetId")?.toInt() ?: -1
+                        val date = intent.getStringExtra("date") ?: ""
+                        val type = intent.getStringExtra("type") ?: ""
+
+                        val intent = navigator.navigateToMain(
+                            this@AuthActivity,
+                            targetId = Pair(EXTRA_TARGET_ID, targetId),
+                            date = Pair(EXTRA_DATE, date),
+                            type = Pair(EXTRA_TYPE, type),
+                        )
                         startActivity(intent)
                     }
                     content.viewTreeObserver.removeOnPreDrawListener(this)

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageScreen.kt
@@ -27,6 +27,7 @@ import com.bff.wespot.message.screen.send.ReceiverSelectionScreenArgs
 import com.bff.wespot.message.state.send.SendAction
 import com.bff.wespot.message.viewmodel.MessageViewModel
 import com.bff.wespot.message.viewmodel.SendViewModel
+import com.bff.wespot.model.notification.NotificationType
 import com.ramcosta.composedestinations.annotation.Destination
 import kotlinx.collections.immutable.persistentListOf
 
@@ -39,6 +40,8 @@ interface MessageNavigator {
 
 data class MessageScreenArgs(
     val isMessageSent: Boolean = false,
+    val type: NotificationType = NotificationType.IDLE,
+    val messageId: Int = -1,
 )
 
 @Destination(navArgsDelegate = MessageScreenArgs::class)
@@ -97,6 +100,8 @@ internal fun MessageScreen(
                     STORAGE_SCREEN_INDEX -> {
                         MessageStorageScreen(
                             viewModel = viewModel,
+                            type = navArgs.type,
+                            messageId = navArgs.messageId,
                             navigateToReservedMessageScreen = {
                                 messageNavigator.navigateToReservedMessageScreen(
                                     args = ReservedMessageScreenArgs(false),
@@ -140,6 +145,12 @@ internal fun MessageScreen(
 
     LaunchedEffect(Unit) {
         messageSentToast = navArgs.isMessageSent
+        when (navArgs.type) {
+            NotificationType.MESSAGE_RECEIVED, NotificationType.MESSAGE_SENT -> {
+                selectedTabIndex = STORAGE_SCREEN_INDEX
+            }
+            else -> { }
+        }
         sendViewModel.onAction(SendAction.OnReservedMessageScreenEntered)
     }
 }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageStorageScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/MessageStorageScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -56,6 +57,7 @@ import com.bff.wespot.message.state.MessageSideEffect
 import com.bff.wespot.message.viewmodel.MessageViewModel
 import com.bff.wespot.model.message.request.MessageType
 import com.bff.wespot.model.message.response.Message
+import com.bff.wespot.model.notification.NotificationType
 import com.bff.wespot.ui.WSBottomSheet
 import com.bff.wespot.ui.WSHomeChipGroup
 import kotlinx.collections.immutable.persistentListOf
@@ -66,6 +68,8 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 @Composable
 fun MessageStorageScreen(
     viewModel: MessageViewModel,
+    type: NotificationType,
+    messageId: Int,
     navigateToReservedMessageScreen: () -> Unit,
     showToast: (String) -> Unit,
 ) {
@@ -84,6 +88,10 @@ fun MessageStorageScreen(
         when (it) {
             is MessageSideEffect.ShowToast -> {
                 showToast(it.message)
+            }
+
+            is MessageSideEffect.ShowMessageDialog -> {
+                showMessageDialog = true
             }
         }
     }
@@ -119,7 +127,12 @@ fun MessageStorageScreen(
                                     WSMessageItemType.UnreadReceivedMessage
                                 },
                                 itemClick = {
-                                    action(MessageAction.OnMessageItemClicked(item))
+                                    action(
+                                        MessageAction.OnMessageItemClicked(
+                                            message = item,
+                                            type = MessageType.RECEIVED,
+                                        ),
+                                    )
                                     showMessageDialog = true
                                 },
                                 optionButtonClick = {
@@ -183,7 +196,12 @@ fun MessageStorageScreen(
                                     else -> WSMessageItemType.UnreadSentMessage
                                 },
                                 itemClick = {
-                                    action(MessageAction.OnMessageItemClicked(item))
+                                    action(
+                                        MessageAction.OnMessageItemClicked(
+                                            message = item,
+                                            type = MessageType.SENT,
+                                        ),
+                                    )
                                     showMessageDialog = true
                                 },
                                 optionButtonClick = {
@@ -281,6 +299,38 @@ fun MessageStorageScreen(
             onDismissRequest = { showMessageOptionDialog = false },
             cancelButtonClick = { showMessageOptionDialog = false },
         )
+    }
+
+    if (state.isLoading) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        when (type) {
+            NotificationType.MESSAGE_RECEIVED -> {
+                selectedChipIndex = RECEIVED_MESSAGE_INDEX
+                action(
+                    MessageAction.OnMessageStorageScreenOpened(
+                        messageId = messageId,
+                        type = MessageType.RECEIVED,
+                    ),
+                )
+            }
+
+            NotificationType.MESSAGE_SENT -> {
+                selectedChipIndex = SENT_MESSAGE_INDEX
+                action(
+                    MessageAction.OnMessageStorageScreenOpened(
+                        messageId = messageId,
+                        type = MessageType.SENT,
+                    ),
+                )
+            }
+
+            else -> { }
+        }
     }
 
     LaunchedEffect(selectedChipIndex) {

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageEditScreen.kt
@@ -86,7 +86,7 @@ fun MessageEditScreen(
             }
 
             is SendSideEffect.NavigateToMessage -> {
-                navigator.navigateMessageScreen(args = MessageScreenArgs(true))
+                navigator.navigateMessageScreen(args = MessageScreenArgs(isMessageSent = true))
             }
 
             is SendSideEffect.NavigateToReservedMessage -> {
@@ -226,7 +226,7 @@ fun MessageEditScreen(
                 okButtonText = stringResource(R.string.send_exit_dialog_ok_button),
                 cancelButtonText = stringResource(id = R.string.close),
                 okButtonClick = {
-                    navigator.navigateMessageScreen(args = MessageScreenArgs(false))
+                    navigator.navigateMessageScreen(args = MessageScreenArgs(isMessageSent = false))
                 },
                 cancelButtonClick = { exitDialog = false },
                 onDismissRequest = { },
@@ -252,7 +252,7 @@ fun MessageEditScreen(
                 okButtonText = stringResource(R.string.positive_answer),
                 cancelButtonText = stringResource(R.string.close),
                 okButtonClick = {
-                    navigator.navigateMessageScreen(args = MessageScreenArgs(false))
+                    navigator.navigateMessageScreen(args = MessageScreenArgs(isMessageSent = false))
                 },
                 cancelButtonClick = { timeoutDialog = false },
                 onDismissRequest = { },

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageWriteScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/MessageWriteScreen.kt
@@ -173,7 +173,7 @@ fun MessageWriteScreen(
             okButtonText = stringResource(R.string.send_exit_dialog_ok_button),
             cancelButtonText = stringResource(id = R.string.close),
             okButtonClick = {
-                navigator.navigateMessageScreen(args = MessageScreenArgs(false))
+                navigator.navigateMessageScreen(args = MessageScreenArgs(isMessageSent = false))
             },
             cancelButtonClick = { dialogState = false },
             onDismissRequest = { },

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/screen/send/ReceiverSelectionScreen.kt
@@ -226,7 +226,7 @@ fun ReceiverSelectionScreen(
             okButtonText = stringResource(R.string.send_exit_dialog_ok_button),
             cancelButtonText = stringResource(id = R.string.close),
             okButtonClick = {
-                navigator.navigateMessageScreen(args = MessageScreenArgs(false))
+                navigator.navigateMessageScreen(args = MessageScreenArgs(isMessageSent = false))
             },
             cancelButtonClick = { dialogState = false },
             onDismissRequest = { },

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageAction.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageAction.kt
@@ -8,7 +8,11 @@ sealed class MessageAction {
     data object OnHomeScreenEntered : MessageAction()
     data object OnReservedMessageScreenEntered : MessageAction()
     data class OnStorageChipSelected(val messageType: MessageType) : MessageAction()
-    data class OnMessageItemClicked(val message: Message) : MessageAction()
+    data class OnMessageStorageScreenOpened(
+        val messageId: Int,
+        val type: MessageType,
+    ) : MessageAction()
+    data class OnMessageItemClicked(val message: Message, val type: MessageType) : MessageAction()
     data class OnOptionButtonClicked(val message: Message) : MessageAction()
     data class OnOptionBottomSheetClicked(
         val messageOptionType: MessageOptionType,

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageSideEffect.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageSideEffect.kt
@@ -1,5 +1,6 @@
 package com.bff.wespot.message.state
 
 sealed class MessageSideEffect {
+    data object ShowMessageDialog : MessageSideEffect()
     data class ShowToast(val message: String) : MessageSideEffect()
 }

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageUiState.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/state/MessageUiState.kt
@@ -17,4 +17,5 @@ data class MessageUiState(
     val optionButtonClickedMessage: Message = Message(),
     val messageOptionType: MessageOptionType = MessageOptionType.DELETE,
     val reservedMessageList: List<Message> = listOf(),
+    val isLoading: Boolean = false,
 )

--- a/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/MessageViewModel.kt
+++ b/feature/message/src/main/kotlin/com/bff/wespot/message/viewmodel/MessageViewModel.kt
@@ -84,7 +84,11 @@ class MessageViewModel @Inject constructor(
                     MessageType.RECEIVED -> getReceivedMessageList()
                 }
             }
-            is MessageAction.OnMessageItemClicked -> handleMessageItemClicked(action.message)
+            is MessageAction.OnMessageStorageScreenOpened -> {
+                handleMessageStorageScreenOpened(action.messageId, action.type)
+            }
+            is MessageAction.OnMessageItemClicked ->
+                handleMessageItemClicked(action.message, action.type)
             is MessageAction.OnOptionButtonClicked -> handleOptionButtonClicked(action.message)
             is MessageAction.OnOptionBottomSheetClicked -> {
                 handleOptionBottomSheetClicked(action.messageOptionType)
@@ -180,14 +184,25 @@ class MessageViewModel @Inject constructor(
         }
     }
 
-    private fun handleMessageItemClicked(message: Message) = intent {
-        reduce {
-            state.copy(
-                clickedMessage = message,
-            )
+    private fun handleMessageStorageScreenOpened(messageId: Int, type: MessageType) = intent {
+        reduce { state.copy(isLoading = true) }
+        viewModelScope.launch {
+            messageRepository.getMessage(messageId)
+                .onSuccess { message ->
+                    handleMessageItemClicked(message = message, type = type)
+                    reduce { state.copy(isLoading = false) }
+                    postSideEffect(MessageSideEffect.ShowMessageDialog)
+                }
+                .onFailure {
+                    reduce { state.copy(isLoading = false) }
+                }
         }
+    }
 
-        if (message.isRead.not()) {
+    private fun handleMessageItemClicked(message: Message, type: MessageType) = intent {
+        reduce { state.copy(clickedMessage = message) }
+
+        if (message.isRead.not() && type == MessageType.RECEIVED) {
             updateMessageReadStatus(messageId = message.id)
         }
     }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
#76 : 푸시 알림 구현 및 권한 / 푸시 알림 화면 전환 

## 2. 🔥 변경된 점

1. 알림 권한이 추가되었습니다.
- MainActivity 생성 시에 권한 체크해서, 없는 경우 요청하도록 구현했어요 !

2. FirebaseCloudMessagingService 메소드 구현 
- onNewToken 발급시에는 로컬 스토리지에 저장 / 새로운 메세지를 받았을 때는 알림으로 호출되도록 구현 / 클릭시 전환할 수 있도록 팬딩 인텐트 구현했어요 

## 3. ✅ 필수 체크 사항 

실제 알림을 받지 않아서, 푸시 알림 테스트는 못해봤습니다 ..!

다만, MainAcitivty에 전환과 관련된 값이 들어왔다는 가정하에 테스트 해봤습니당 

## 4. 📸 작업물 사진 공유(선택)

<img width="345" alt="스크린샷 2024-08-11 오후 3 59 53" src="https://github.com/user-attachments/assets/614acbf4-fe78-4729-a9ed-48122b80fd4b">

[notificiation_message.webm](https://github.com/user-attachments/assets/42e51a89-b5b4-4f28-9d4f-ecae0e3ca10a)

## 5. 💡알게된 혹은 궁금한 사항
